### PR TITLE
Add set value function

### DIFF
--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -239,6 +239,14 @@ open class Element: Node {
         evaluate(javaScript: js, completionHandler: completionHandler)
     }
 
+    open func set(value: String?, completionHandler: CompletionHandler? = nil) {
+        let js = jsValue(value)
+        #if TEST
+            print("js:\(js)")
+        #endif
+        evaluate(javaScript: js, completionHandler: completionHandler)
+    }
+
     open func click(completionHandler: CompletionHandler? = nil) {
         evaluate(javaScript: jsFunction("click"), completionHandler: completionHandler)
     }
@@ -265,6 +273,16 @@ open class Element: Node {
             js += "\(varName).setAttribute('\(attr)', '\(v)');\n"
         } else {
             js += "\(varName).removeAttribute('\(attr)');\n"
+        }
+        return js
+    }
+
+    func jsValue(_ value: String?, varName: String = "erik") -> String {
+        var js = jsSelector(varName)
+        if let v = value {
+            js += "\(varName).value = '\(v)';"
+        } else {
+            js += "\(varName).value = '';"
         }
         return js
     }


### PR DESCRIPTION
Added method to access HTML value property.

ref: https://developer.mozilla.org/en/docs/Web/API/Element/setAttribute
> Using setAttribute() to modify certain attributes, most notably value in XUL, works inconsistently, as the attribute specifies the default value. To access or modify the current values, you should use the properties. For example, use elt.value instead of elt.setAttribute('value', val).