### PR TITLE
[Proposal] Added index property to access the correct element

### DIFF
--- a/Sources/Document.swift
+++ b/Sources/Document.swift
@@ -262,9 +262,9 @@ open class Element: Node {
 
     open func set(value: String?, completionHandler: CompletionHandler? = nil) {
         let js = jsValue(value)
-        //#if TEST
+        #if TEST
             print("js:\(js)")
-        //#endif
+        #endif
         evaluate(javaScript: js, completionHandler: completionHandler)
     }
 
@@ -311,9 +311,9 @@ open class Element: Node {
     func jsFunction(_ name: String, varName: String = "erik") -> String {
         var js = jsSelector(varName) // TODO check undefined?
         js += "\(varName).\(name)();\n"
-        //#if TEST
+        #if TEST
             print("js:\(js)")
-        //#endif
+        #endif
         return js
     }
 


### PR DESCRIPTION
The correct element could not be used when specifying the following selector.

swift code.
```
let input = doc.querySelectorAll("input")[1]
input.set(value: "value")
```

Converted javascript.
```
js:var erik = document;
erik = erik.querySelectorAll('input')[0]; // always 0
erik.value = 'value';
```

So, I added index to the element and use that index.
How about this implementation?