### PR TITLE
Update LayoutEngine.swift (Swift 4 Upgrade)

### DIFF
--- a/Sources/LayoutEngine.swift
+++ b/Sources/LayoutEngine.swift
@@ -133,7 +133,7 @@ open class WebKitLayoutEngine: NSObject, LayoutEngine {
     open fileprivate(set) var firstPageLoaded = false
 
     // Serial queue where javascript is executed
-    open var javaScriptQueue = DispatchQueue(label: "ErikJavaScript")
+    open var javaScriptQueue = DispatchQueue.main
     // Serial queue where functions callbacks are executed
     open var callBackQueue = DispatchQueue(label: "ErikCallBack")
     // Serial queue where Erik wait for page loading
@@ -272,10 +272,10 @@ extension WebKitLayoutEngine {
     }
     
     fileprivate func handleHTML(_ completionHandler: CompletionHandler?) {
-        DispatchQueue.main.async { [unowned self] in
+        javaScriptQueue.async { [unowned self] in
          
             self.webView.evaluateJavaScript(self.javascriptToGetContent.javascript) { (obj, error) -> Void in
-                DispatchQueue.main.async {
+                javaScriptQueue.async {
                     completionHandler?(obj, error)
                 }
             }

--- a/Sources/LayoutEngine.swift
+++ b/Sources/LayoutEngine.swift
@@ -86,6 +86,7 @@ open class WebKitLayoutEngine: NSObject, LayoutEngine {
             case .navigationDelegate:
                 return { engine in
                     if let delegate = engine.navigable {
+                        assert(engine.navigable as? WKNavigationDelegate === engine.webView.navigationDelegate)
                         return delegate.navigate
                     }
                     assertionFailure("No navigation deletage found")
@@ -132,7 +133,7 @@ open class WebKitLayoutEngine: NSObject, LayoutEngine {
     open fileprivate(set) var firstPageLoaded = false
 
     // Serial queue where javascript is executed
-    open var javaScriptQueue = DispatchQueue.main
+    open var javaScriptQueue = DispatchQueue(label: "ErikJavaScript")
     // Serial queue where functions callbacks are executed
     open var callBackQueue = DispatchQueue(label: "ErikCallBack")
     // Serial queue where Erik wait for page loading
@@ -271,10 +272,10 @@ extension WebKitLayoutEngine {
     }
     
     fileprivate func handleHTML(_ completionHandler: CompletionHandler?) {
-        javaScriptQueue.async { [unowned self] in
+        DispatchQueue.main.async { [unowned self] in
          
-            self.webView.evaluateJavaScript(self.javascriptToGetContent.javascript) { [unowned self] (obj, error) -> Void in
-                self.callBackQueue.async {
+            self.webView.evaluateJavaScript(self.javascriptToGetContent.javascript) { (obj, error) -> Void in
+                DispatchQueue.main.async {
                     completionHandler?(obj, error)
                 }
             }
@@ -407,7 +408,7 @@ extension WebKitLayoutEngine: Semaphorable {}
 
 protocol Semaphorable: AnyObject {}
 
-class SemaphoreBox: AnyObject  {
+class SemaphoreBox  {
     let semaphore = DispatchSemaphore(value: 0)
     var object: AnyObject?
 }
@@ -457,17 +458,23 @@ extension Semaphorable {
     
     var semaphores: [SemaphorableKey: SemaphoreBox] {
         get {
-            if let o = objc_getAssociatedObject(self, SemaphorableKeys.semaphores) as? [SemaphorableKey: SemaphoreBox]  {
+            if let semaphores = SemaphorableKeys.semaphores, let o = objc_getAssociatedObject(self, semaphores) as? [SemaphorableKey: SemaphoreBox]  {
                 return o
             }
             else {
                 let obj = [SemaphorableKey: SemaphoreBox]()
-                objc_setAssociatedObject(self, SemaphorableKeys.semaphores, obj, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                if let semaphores = SemaphorableKeys.semaphores {
+                     objc_setAssociatedObject(self, semaphores, obj, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                }
+               
                 return obj
             }
         }
         set {
-            objc_setAssociatedObject(self, SemaphorableKeys.semaphores, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+             if let semaphores = SemaphorableKeys.semaphores {
+                 objc_setAssociatedObject(self, semaphores, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+           
         }
     }
 

--- a/Sources/LayoutEngine.swift
+++ b/Sources/LayoutEngine.swift
@@ -274,8 +274,8 @@ extension WebKitLayoutEngine {
     fileprivate func handleHTML(_ completionHandler: CompletionHandler?) {
         javaScriptQueue.async { [unowned self] in
          
-            self.webView.evaluateJavaScript(self.javascriptToGetContent.javascript) { (obj, error) -> Void in
-                javaScriptQueue.async {
+            self.webView.evaluateJavaScript(self.javascriptToGetContent.javascript) { [unowned self] (obj, error) -> Void in
+                self.javaScriptQueue.async {
                     completionHandler?(obj, error)
                 }
             }


### PR DESCRIPTION
I have:
- safely unwrapped the semaphores 
- Removed inheritance from AnyObject
- Moved the javascript completion handler to the Main Thread, since the new Main Thread Checker was complaining about UI changes (https://developer.apple.com/documentation/code_diagnostics/main_thread_checker). Not sure if this is the correct way